### PR TITLE
Fix for pause and resume in 0.10.x KafkaConsumer

### DIFF
--- a/src/kinsky/client.clj
+++ b/src/kinsky/client.clj
@@ -371,12 +371,10 @@
        (.wakeup consumer))
      (pause! [this topic-partitions]
        (.pause consumer
-               (into-array TopicPartition (map ->topic-partition
-                                               topic-partitions))))
+               (map ->topic-partition topic-partitions)))
      (resume! [this topic-partitions]
        (.resume consumer
-                (into-array TopicPartition (map ->topic-partition
-                                                topic-partitions))))
+                (map ->topic-partition topic-partitions)))
      (subscribe! [this topics]
        (assert (or (string? topics)
                    (keyword? topics)

--- a/src/kinsky/client.clj
+++ b/src/kinsky/client.clj
@@ -367,7 +367,8 @@
      (poll! [this timeout]
        (consumer-records->data (.poll consumer timeout)))
      (stop! [this timeout]
-       (run-signal)
+       (when run-signal
+         (run-signal))
        (.wakeup consumer))
      (pause! [this topic-partitions]
        (.pause consumer


### PR DESCRIPTION
As of kafka-clients 0.10.0, `KafkaConsumer.pause()` and `.resume()` take a Java `Collection` of partitions, not an array:

http://kafka.apache.org/0100/javadoc/index.html?org/apache/kafka/clients/consumer/KafkaConsumer.html
