### PR TITLE
kafka-consumer-loop thread should be a daemon thread. 

### DIFF
--- a/src/kinsky/async.clj
+++ b/src/kinsky/async.clj
@@ -162,7 +162,7 @@
          driver          (make-consumer config  kd vd)
          gateway         (a/chan inbuf)
          [ctl out next!] (poller-fn driver inbuf outbuf timeout)]
-     (future
+     (a/thread
        (.setName (Thread/currentThread) "kafka-consumer-loop")
        (loop [poller (next!)]
          (a/alt!!


### PR DESCRIPTION
Just recognized that applications using the consumer have to be terminated with a SIGKILL as they do not shut down on a SIGTERM. Having the kafka-consumer-loop running in a daemon thread like kafka-record-poller fixes this.