### PR TITLE
async: ensure we wake up before perfoming admin tasks

### DIFF
--- a/src/kinsky/async.clj
+++ b/src/kinsky/async.clj
@@ -86,6 +86,7 @@
     (let [{:keys [op]}  payload
           topic-offsets (:topic-offsets payload)
           topic         (or (:topics payload) (:topic payload))]
+      (client/wake-up! driver)
       (cond
         (= op :callback)
         (let [f (:callback payload)]

--- a/src/kinsky/async.clj
+++ b/src/kinsky/async.clj
@@ -86,7 +86,6 @@
     (let [{:keys [op]}  payload
           topic-offsets (:topic-offsets payload)
           topic         (or (:topics payload) (:topic payload))]
-      (client/wake-up! driver)
       (cond
         (= op :callback)
         (let [f (:callback payload)]
@@ -151,13 +150,24 @@
   "Poll for next messages, catching exceptions and yielding them."
   [driver inbuf outbuf timeout]
   (let [ctl      (a/chan inbuf)
+        mult     (a/mult ctl)
+        c1       (a/chan inbuf)
+        c2       (a/chan inbuf)
         out      (a/chan outbuf)
         recs     (a/chan outbuf record-xform (fn [e] (throw e)))]
+    (a/tap mult c1)
+    (a/tap mult c2)
     (a/pipe recs out)
+    (future
+      (.setName (Thread/currentThread) "kafka-control-poller")
+      (loop []
+        (when-let [cr (a/<!! c2)]
+          (client/wake-up! driver)
+          (recur))))
     (future
       (.setName (Thread/currentThread) "kafka-consumer-poller")
       (loop []
-        (let [recur? (safe-poll ctl recs out driver timeout)]
+        (let [recur? (safe-poll c1 recs out driver timeout)]
           (if recur?
             (recur)
             (close-poller ctl out driver)))))


### PR DESCRIPTION
As it stands, there is no way for control records to trigger a wake up of the driver, which thus
prevent administrative tasks from happening.

This adds a polling thread which wakes up the driver on incoming control messages.