### PR TITLE
Fix async consumer ConcurrentModificationException

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Kinsky provides the following:
 
 ### 0.1.23
 
-- 
+- Fixed ConcurrentModificationException when async consumer created with topic
 
 ### 0.1.22
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Kinsky provides the following:
 
 ## Changelog
 
+### 0.1.23
+
+- 
+
 ### 0.1.22
 
 - Update to latest Kafka clients

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject spootnik/kinsky "0.1.22"
+(defproject spootnik/kinsky "0.1.23-SNAPSHOT"
   :description "Kafka clojure client library"
   :plugins [[lein-codox "0.9.1"]
             [lein-ancient "0.6.15"]]


### PR DESCRIPTION
When creating the consumer given some topic to subscribe to, the subscription operation was done by calling the client driver directly, which has the adverse effect of pinning the underlying kafka consumer to the calling thread, thus making the poller thread throw a ConcurrentModificationException. Instead of calling the driver, send a subscribe operation.