### PR TITLE
Add support for producer's transactional functions

### DIFF
--- a/src/kinsky/client.clj
+++ b/src/kinsky/client.clj
@@ -175,11 +175,16 @@
 
 (defn edn-deserializer
   "Deserialize EDN."
-  []
-  (deserializer
-   (fn [_ #^"[B" payload]
-     (when payload
-       (edn/read-string (String. payload "UTF-8"))))))
+  ([]
+   (deserializer
+    (fn [_ #^"[B" payload]
+      (when payload
+        (edn/read-string (String. payload "UTF-8"))))))
+  ([reader-opts]
+   (deserializer
+    (fn [_ #^"[B" payload]
+      (when payload
+        (edn/read-string reader-opts (String. payload "UTF-8")))))))
 
 (defn json-deserializer
   "Deserialize JSON."
@@ -333,6 +338,7 @@
   {:key       (.key cr)
    :offset    (.offset cr)
    :partition (.partition cr)
+   :timestamp (.timestamp cr)
    :topic     (.topic cr)
    :value     (.value cr)})
 


### PR DESCRIPTION
This exposes the following methods in `kinsky.client`. Tested in a project at work

-  initTransactions
-  beginTransaction
-  commitTransaction

c.f. https://kafka.apache.org/11/javadoc/org/apache/kafka/clients/producer/Producer.html#initTransactions--