### PR TITLE
Feature/lac deserializer for JSON events

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,8 @@
   :dependencies [[org.clojure/clojure            "1.10.0"]
                  [org.clojure/core.async         "0.4.490"]
                  [org.apache.kafka/kafka-clients "2.1.0"]
-                 [cheshire                       "5.8.1"]]
+                 [cheshire                       "5.8.1"]
+                 [org.clojure/tools.logging      "0.4.1"]]
   :test-selectors {:default     (complement :integration)
                    :integration :integration
                    :all         (constantly true)}

--- a/src/kinsky/client.clj
+++ b/src/kinsky/client.clj
@@ -198,6 +198,18 @@
      (when payload
        (json/parse-string (String. payload "UTF-8") true)))))
 
+(defn json-deserializer-lac
+  "Deserialize JSON, on error, log and continue."
+  []
+  (deserializer
+   (fn [_ #^"[B" payload]
+     (when payload
+       (try
+         (json/parse-string (String. payload "UTF-8") true)
+         (catch Exception e
+           (println "JSON parse exception")
+           {:error "Bad Message Detected" :message (String. payload "UTF-8")}))))))
+
 (defn keyword-deserializer
   "Deserialize a string and then keywordize it."
   []

--- a/src/kinsky/client.clj
+++ b/src/kinsky/client.clj
@@ -2,7 +2,8 @@
   "Small clojure shim on top of the Kafka client API
    See https://github.com/pyr/kinsky for example usage."
   (:require [clojure.edn           :as edn]
-            [cheshire.core         :as json])
+            [cheshire.core         :as json]
+            [clojure.tools.logging :as log])
   (:import java.util.Collection
            java.util.Map
            java.util.concurrent.TimeUnit
@@ -207,7 +208,7 @@
        (try
          (json/parse-string (String. payload "UTF-8") true)
          (catch Exception e
-           (println "JSON parse exception")
+           (log/error e  "JSON parse exception")
            {:error "Bad Message Detected" :message (String. payload "UTF-8")}))))))
 
 (defn keyword-deserializer

--- a/src/kinsky/client.clj
+++ b/src/kinsky/client.clj
@@ -209,7 +209,7 @@
          (json/parse-string (String. payload "UTF-8") true)
          (catch Exception e
            (log/error e  "JSON parse exception")
-           {:error "Bad Message Detected" :message (String. payload "UTF-8")}))))))
+           {:json-deserializer-error "Bad Message Detected" :message (String. payload "UTF-8")}))))))
 
 (defn keyword-deserializer
   "Deserialize a string and then keywordize it."

--- a/test/kinsky/client_test.clj
+++ b/test/kinsky/client_test.clj
@@ -40,7 +40,11 @@
   (testing "json deserializer"
     (is (= {:a "b" :c "d"}
            (.deserialize (client/json-deserializer) ""
-                         (.getBytes "{\"a\": \"b\", \"c\": \"d\"}"))))))
+                         (.getBytes "{\"a\": \"b\", \"c\": \"d\"}")))))
+  (testing "json deserializer, log and continue on error"
+    (is (= {:error "Bad Message Detected" :message "F00"}
+           (.deserialize (client/json-deserializer-lac) ""
+                         (.getBytes "F00"))))))
 
 (deftest config-props
   (testing "valid configuration properties"

--- a/test/kinsky/client_test.clj
+++ b/test/kinsky/client_test.clj
@@ -43,7 +43,7 @@
                          (.getBytes "{\"a\": \"b\", \"c\": \"d\"}")))))
 
   (testing "json deserializer, log and continue on error"
-    (is (= {:error "Bad Message Detected" :message "F00"}
+    (is (= {:json-deserializer-error "Bad Message Detected" :message "F00"}
            (.deserialize (client/json-deserializer-lac) ""
                          (.getBytes "F00"))))))
 

--- a/test/kinsky/client_test.clj
+++ b/test/kinsky/client_test.clj
@@ -41,6 +41,7 @@
     (is (= {:a "b" :c "d"}
            (.deserialize (client/json-deserializer) ""
                          (.getBytes "{\"a\": \"b\", \"c\": \"d\"}")))))
+
   (testing "json deserializer, log and continue on error"
     (is (= {:error "Bad Message Detected" :message "F00"}
            (.deserialize (client/json-deserializer-lac) ""


### PR DESCRIPTION
I found it impossible to process a poisoned JSON formatted event as by the time the client/poll! function received the exception, the events had been lost. So I added a Log And Continue JSON deserializer that as the name says, in the case of one of the events being un-parseable, logs an error message using the clojure.tools.logging package, and returns a {:json-deserializer-error: "Bad Message Detected" :message { (String. payload)} map back. This way the consumer can detect a poison message and continue processing, or if it choses, abort processing.

I could not think of a reason why the payload could not be represented as a string in the :message tag, but I could be wrong.