### PR TITLE
Added support for Kafka message headers which were added in v0.11.0.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 language: clojure
 lein: lein


### PR DESCRIPTION
The ability to add custom headers to Kafka messages was added in v0.11.0.0. I don't think they are a very good idea as it leaves metadata out of band and you will have to add extra processing to process the event and headers but what the hell, they are there and people are using them, I needed to be able to see them.

The code adds a new send! function that takes a {:header "map"} and defaults the timestamp and partition to 0.

The ->record function is modified to add the 3 new Java producer record methods which take Headers and has added the :headers and :timestamp keywords.

A ->header function reify's the org.apache.kafka.common.header.Header interface (I did borrow from https://github.com/Dangercoder/kinsky as I got a bit stuck there) and a ->headers function takes a Clojure map and implements the org.apache.kafka.common.header.Headers interface. No code needed as the returned Clojure object implements java.lang.Iterable which is all the ProducerRecord wants. 
Keyword keys are converted to String in the Header, and values are converted to byte arrays. When consuming the Headers duplicate keys are a valid scenario so the returned map contains the header values in a vector as there could be multiple values for the same header. Again, don't ask me why, it seems a silly idea, but that's how it is.