### PR TITLE
Feature/improve consumer

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
             :url  "https://github.com/pyr/kinsky/tree/master/LICENSE"}
   :codox {:source-uri "https://github.com/pyr/kinsky/blob/{version}/{filepath}#L{line}"
           :metadata   {:doc/format :markdown}}
+  :global-vars {*warn-on-reflection* true}
   :dependencies [[org.clojure/clojure            "1.10.0"]
                  [org.clojure/core.async         "0.4.490"]
                  [org.apache.kafka/kafka-clients "2.3.0"]


### PR DESCRIPTION
* make the consumer-driver ConsumerRecords decoding configurable. It is done from second arg that is now a map with potentially :kinsky.client/consumer-decoder-fn key present, defaulting to kinsky.client/consumer-records->data (backward compat)

* add helpers to shape ConsumerRecords from that new option
simplify consumer-records->data

* modify kinsky.client/consumer to support this new options: consumer map can now include the extra drivers options keys and will remove them before passing the "rest" to the underlying kafka KafkaConsumer.