### PR TITLE
Fix typo in json-serializer docstring

### DIFF
--- a/src/kinsky/client.clj
+++ b/src/kinsky/client.clj
@@ -157,7 +157,7 @@
    (fn [_ payload] (some-> payload pr-str .getBytes))))
 
 (defn json-serializer
-  "Serialize as JSON through cheshire."
+  "Serialize as JSON through jsonista."
   []
   (serializer
    (fn [_ payload] (some-> payload json/write-value-as-bytes))))


### PR DESCRIPTION
jsonista is used to serialize JSON instead of cheshire.