### PR TITLE
Fixes reflection issues

### DIFF
--- a/src/kinsky/client.clj
+++ b/src/kinsky/client.clj
@@ -152,23 +152,27 @@
 
 (defn edn-serializer
   "Serialize as EDN."
+  ^Serializer
   []
   (serializer
    (fn [_ payload] (some-> payload pr-str .getBytes))))
 
 (defn json-serializer
   "Serialize as JSON through jsonista."
+  ^Serializer
   []
   (serializer
    (fn [_ payload] (some-> payload json/write-value-as-bytes))))
 
 (defn keyword-serializer
   "Serialize keywords to strings, useful for keys."
+  ^Serializer
   []
   (serializer (fn [_ k] (some-> k name .getBytes))))
 
 (defn string-serializer
   "Kafka's own string serializer."
+  ^StringSerializer
   []
   (StringSerializer.))
 
@@ -185,12 +189,12 @@
 
 (defn edn-deserializer
   "Deserialize EDN."
-  ([]
+  (^Deserializer []
    (deserializer
     (fn [_ #^"[B" payload]
       (when payload
         (edn/read-string (String. payload "UTF-8"))))))
-  ([reader-opts]
+  (^Deserializer [reader-opts]
    (deserializer
     (fn [_ #^"[B" payload]
       (when payload
@@ -198,6 +202,7 @@
 
 (defn json-deserializer
   "Deserialize JSON."
+  ^Deserializer
   []
   (let [mapper (json/object-mapper {:encode-key-fn name
                                     :decode-key-fn keyword})]
@@ -208,11 +213,13 @@
 
 (defn keyword-deserializer
   "Deserialize a string and then keywordize it."
+  ^Deserializer
   []
   (deserializer (fn [_ #^"[B" k] (when k (keyword (String. k "UTF-8"))))))
 
 (defn string-deserializer
   "Kafka's own string deserializer"
+  ^StringDeserializer
   []
   (StringDeserializer.))
 
@@ -228,7 +235,8 @@
    :string  string-serializer
    :json    json-serializer})
 
-(defn ^Deserializer ->deserializer
+(defn ->deserializer
+  ^Deserializer
   [x]
   (cond
     (keyword? x) (if-let [f (deserializers x)]
@@ -539,6 +547,7 @@
 (defn ->record
   "Build a producer record from a clojure map. Leave ProducerRecord instances
    untouched."
+  ^ProducerRecord
   [payload]
   (if (instance? ProducerRecord payload)
     payload

--- a/test/kinsky/embedded.clj
+++ b/test/kinsky/embedded.clj
@@ -76,7 +76,7 @@
   [^ServerCnxnFactory server-cnxn-factory]
   (when server-cnxn-factory
     (.shutdown server-cnxn-factory)
-    (when-let [server ^ZooKeeperServer (-> (doto (.getDeclaredMethod ServerCnxnFactory
+    (when-let [^ZooKeeperServer server (-> (doto (.getDeclaredMethod ServerCnxnFactory
                                                                      "getZooKeeperServer"
                                                                      (make-array Class 0))
                                              (.setAccessible true))


### PR DESCRIPTION
Added type hints, type hint ordering following the recommendations from https://clojure.org/reference/vars#metadata.

```sh
 ~/e/kinsky   master  lein test
Reflection warning, kinsky/embedded.clj:85:7 - reference to field shutdown on java.lang.Object can't be resolved.
Reflection warning, kinsky/embedded.clj:86:15 - reference to field getZKDatabase on java.lang.Object can't be resolved.
Reflection warning, kinsky/embedded.clj:86:39 - reference to field close can't be resolved.
Reflection warning, kinsky/client_test.clj:35:13 - call to method serialize can't be resolved (target class is unknown).
Reflection warning, kinsky/client_test.clj:34:12 - call to java.lang.String ctor can't be resolved.
Reflection warning, kinsky/client_test.clj:40:13 - call to method serialize can't be resolved (target class is unknown).
Reflection warning, kinsky/client_test.clj:39:12 - call to java.lang.String ctor can't be resolved.
Reflection warning, kinsky/client_test.clj:45:13 - call to method serialize can't be resolved (target class is unknown).
Reflection warning, kinsky/client_test.clj:44:12 - call to java.lang.String ctor can't be resolved.
Reflection warning, kinsky/client_test.clj:50:13 - call to method serialize can't be resolved (target class is unknown).
Reflection warning, kinsky/client_test.clj:49:12 - call to java.lang.String ctor can't be resolved.
Reflection warning, kinsky/client_test.clj:54:18 - call to method deserialize can't be resolved (target class is unknown).
Reflection warning, kinsky/client_test.clj:58:17 - call to method deserialize can't be resolved (target class is unknown).
Reflection warning, kinsky/client_test.clj:63:12 - call to method deserialize can't be resolved (target class is unknown).
Reflection warning, kinsky/client_test.clj:68:12 - call to method deserialize can't be resolved (target class is unknown).
Reflection warning, kinsky/client_test.clj:206:20 - call to org.apache.kafka.clients.producer.ProducerRecord ctor can't be resolved.
Reflection warning, kinsky/client_test.clj:217:12 - reference to field toString can't be resolved.
Reflection warning, kinsky/client_test.clj:219:12 - reference to field toString can't be resolved.
Reflection warning, kinsky/client_test.clj:221:12 - reference to field toString can't be resolved.
Reflection warning, kinsky/client_test.clj:223:12 - reference to field toString can't be resolved.
Reflection warning, kinsky/client_test.clj:225:12 - reference to field toString can't be resolved.
Reflection warning, kinsky/client_test.clj:227:12 - reference to field toString can't be resolved.
Reflection warning, kinsky/client_test.clj:228:118 - reference to field toString can't be resolved.

lein test kinsky.client-test

Ran 9 tests containing 30 assertions.
0 failures, 0 errors.
```

```sh
 ~/e/kinsky   fix-reflection  lein test
Reflection warning, kinsky/client_test.clj:206:20 - call to org.apache.kafka.clients.producer.ProducerRecord ctor can't be resolved.

lein test kinsky.client-test

Ran 9 tests containing 30 assertions.
0 failures, 0 errors.
